### PR TITLE
Permit ADQL library build for java5

### DIFF
--- a/buildADQL.xml
+++ b/buildADQL.xml
@@ -87,7 +87,7 @@
 	
 	<target name="compileLib" depends="clean,junitValidation" description="Build all the classes of the ADQL library. This target is particularly usefull because it lets highlighting missing dependencies.">
 		<mkdir dir="${compileDir}" />
-		<javac destdir="${compileDir}" srcdir="${srcDir}" includes="${includesList}" includeantruntime="false" encoding="utf8">
+		<javac destdir="${compileDir}" srcdir="${srcDir}" includes="${includesList}" includeantruntime="false" encoding="utf8" bootclasspath="${adql.bootclasspath}">
 			<classpath refid="adql.classpath" />
 		</javac>
 	</target>

--- a/src/adql/db/DBChecker.java
+++ b/src/adql/db/DBChecker.java
@@ -215,7 +215,9 @@ public class DBChecker implements QueryChecker {
 					tmp[cnt++] = udf;
 			}
 			// make a copy of the array:
-			this.allowedUdfs = Arrays.copyOf(tmp, cnt, FunctionDef[].class);
+                        this.allowedUdfs = new FunctionDef[cnt];
+                        System.arraycopy(tmp, 0, this.allowedUdfs, 0, cnt);
+
 			tmp = null;
 			// sort the values:
 			Arrays.sort(this.allowedUdfs);
@@ -318,7 +320,8 @@ public class DBChecker implements QueryChecker {
 		}
 
 		// Make an adjusted array copy:
-		String[] copy = Arrays.copyOf(tmp, cnt);
+		String[] copy = new String[cnt];
+                System.arraycopy(tmp, 0, copy, 0, cnt);
 
 		// Sort the values:
 		Arrays.sort(copy);

--- a/src/adql/db/exception/UnresolvedIdentifiersException.java
+++ b/src/adql/db/exception/UnresolvedIdentifiersException.java
@@ -66,15 +66,15 @@ public class UnresolvedIdentifiersException extends ParseException implements It
 			exceptions.add(pe);
 			if (pe instanceof UnresolvedColumnException){
 				String colName = ((UnresolvedColumnException)pe).getColumnName();
-				if (colName != null && !colName.trim().isEmpty())
+				if (colName != null && colName.trim().length()>0)
 					addIdentifierName(colName + " " + pe.getPosition());
 			}else if (pe instanceof UnresolvedTableException){
 				String tableName = ((UnresolvedTableException)pe).getTableName();
-				if (tableName != null && !tableName.trim().isEmpty())
+				if (tableName != null && tableName.trim().length()>0)
 					addIdentifierName(tableName + " " + pe.getPosition());
 			}else if (pe instanceof UnresolvedFunctionException){
 				String fctName = (((UnresolvedFunctionException)pe).getFunction() == null) ? null : ((UnresolvedFunctionException)pe).getFunction().getName() + "(...)";
-				if (fctName != null && !fctName.trim().isEmpty())
+				if (fctName != null && fctName.trim().length()>0)
 					addIdentifierName(fctName /*+ " " + pe.getPosition()*/);	// TODO Add the position of the function in the ADQL query!
 			}else if (pe instanceof UnresolvedIdentifiersException)
 				addIdentifierName(((UnresolvedIdentifiersException)pe).unresolvedIdentifiers);
@@ -87,7 +87,7 @@ public class UnresolvedIdentifiersException extends ParseException implements It
 	 * @param name	Name (or description) of the identifier to add.
 	 */
 	private final void addIdentifierName(final String name){
-		if (name != null && !name.trim().isEmpty()){
+		if (name != null && name.trim().length()>0){
 			if (unresolvedIdentifiers == null)
 				unresolvedIdentifiers = "";
 			else

--- a/src/adql/parser/ADQLParser.java
+++ b/src/adql/parser/ADQLParser.java
@@ -398,7 +398,7 @@ public class ADQLParser implements ADQLParserConstants {
 
 		try{
 
-			if (file == null || file.isEmpty())
+			if (file == null || file.length()==0)
 				parser = new ADQLParser(System.in);
 			else if (file.matches(urlRegex))
 				parser = new ADQLParser((new java.net.URL(file)).openStream());


### PR DESCRIPTION
A small number of changes are required to allow the ADQL library to be built to run in a java 5 JRE.
There are just a couple of methods introduced at java6 that can easily be replaced by java 5 equivalents.
This PR contains these changes.

I'm currently still targetting starjava (topcat/stilts) for java5, so I've made these changes for my copy and recompiled before using the library.  Probably nobody else out there is using such ancient technology, and possibly I won't be for too much longer, so if you don't want to incorporate these into the master it's OK.
But they are pretty harmless changes.