### PR TITLE
Allow ADQL Operands in group by clause

### DIFF
--- a/src/adql/db/DBChecker.java
+++ b/src/adql/db/DBChecker.java
@@ -369,7 +369,7 @@ public class DBChecker implements QueryChecker {
 	 * @see #check(ADQLQuery, Stack)
 	 */
 	@Override
-	public final void check(final ADQLQuery query) throws ParseException{
+	public void check(final ADQLQuery query) throws ParseException{
 		check(query, null);
 	}
 

--- a/src/adql/db/DBChecker.java
+++ b/src/adql/db/DBChecker.java
@@ -102,7 +102,7 @@ import adql.search.SimpleSearchHandler;
 public class DBChecker implements QueryChecker {
 
 	/** List of all available tables ({@link DBTable}). */
-	protected SearchTableList lstTables;
+	protected SearchTableApi lstTables;
 
 	/** <p>List of all allowed geometrical functions (i.e. CONTAINS, REGION, POINT, COORD2, ...).</p>
 	 * <p>
@@ -574,7 +574,7 @@ public class DBChecker implements QueryChecker {
 	 * @throws ParseException	An {@link UnresolvedTableException} if the given table can't be resolved.
 	 */
 	protected DBTable resolveTable(final ADQLTable table) throws ParseException{
-		ArrayList<DBTable> tables = lstTables.search(table);
+		List<DBTable> tables = lstTables.search(table);
 
 		// good if only one table has been found:
 		if (tables.size() == 1)

--- a/src/adql/db/SearchTableApi.java
+++ b/src/adql/db/SearchTableApi.java
@@ -1,0 +1,21 @@
+package adql.db;
+
+import java.util.List;
+
+import adql.query.from.ADQLTable;
+
+public interface SearchTableApi
+    {
+
+    /**
+     * Searches all {@link DBTable} elements corresponding to the given {@link ADQLTable} (case insensitive).
+     * 
+     * @param table	An {@link ADQLTable}.
+     * 
+     * @return		The list of all corresponding {@link DBTable} elements.
+     * 
+     * @see #search(String, String, String, byte)
+     */
+    public List<DBTable> search(final ADQLTable table);
+
+    }

--- a/src/adql/db/SearchTableList.java
+++ b/src/adql/db/SearchTableList.java
@@ -38,7 +38,7 @@ import cds.utils.TextualSearchList;
  * @author Gr&eacute;gory Mantelet (CDS;ARI)
  * @version 1.3 (02/2015)
  */
-public class SearchTableList extends TextualSearchList<DBTable> {
+public class SearchTableList extends TextualSearchList<DBTable> implements SearchTableApi{
 	private static final long serialVersionUID = 1L;
 
 	/** Indicates whether multiple occurrences are allowed. */

--- a/src/adql/parser/ADQLParser.java
+++ b/src/adql/parser/ADQLParser.java
@@ -771,10 +771,10 @@ public class ADQLParser implements ADQLParserConstants {
   final public void GroupBy() throws ParseException {
     trace_call("GroupBy");
     try {
-                 ClauseADQL<ColumnReference> groupBy = query.getGroupBy(); ColumnReference colRef = null;
+                 ClauseADQL<ADQLOperand> groupBy = query.getGroupBy(); ADQLOperand colRef = null;
       jj_consume_token(GROUP_BY);
-      colRef = ColumnRef();
-                                        groupBy.add(colRef);
+      colRef = ValueExpression();
+                                              groupBy.add(colRef);
       label_3:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -786,8 +786,8 @@ public class ADQLParser implements ADQLParserConstants {
           break label_3;
         }
         jj_consume_token(COMMA);
-        colRef = ColumnRef();
-                                       groupBy.add(colRef);
+        colRef = ValueExpression();
+                                             groupBy.add(colRef);
       }
     } finally {
       trace_return("GroupBy");
@@ -3195,11 +3195,11 @@ public class ADQLParser implements ADQLParserConstants {
   private boolean jj_3R_163() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_185()) jj_scanpos = xsp;
-    if (jj_3R_186()) return true;
+    if (jj_3R_184()) jj_scanpos = xsp;
+    if (jj_3R_185()) return true;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_187()) { jj_scanpos = xsp; break; }
+      if (jj_3R_186()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
@@ -3321,15 +3321,15 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_174() {
+  private boolean jj_3R_173() {
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_191()) return true;
+    if (jj_3R_189()) return true;
     return false;
   }
 
-  private boolean jj_3R_173() {
+  private boolean jj_3R_172() {
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_191()) return true;
+    if (jj_3R_189()) return true;
     return false;
   }
 
@@ -3378,7 +3378,7 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_168() {
+  private boolean jj_3R_167() {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_scan_token(10)) {
@@ -3444,7 +3444,7 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_172() {
+  private boolean jj_3R_171() {
     if (jj_3R_108()) return true;
     return false;
   }
@@ -3459,7 +3459,7 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_3R_34()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_168()) jj_scanpos = xsp;
+    if (jj_3R_167()) jj_scanpos = xsp;
     return false;
   }
 
@@ -3642,7 +3642,7 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_3R_108()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_174()) jj_scanpos = xsp;
+    if (jj_3R_173()) jj_scanpos = xsp;
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
   }
@@ -3671,7 +3671,7 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_3R_108()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_173()) jj_scanpos = xsp;
+    if (jj_3R_172()) jj_scanpos = xsp;
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
   }
@@ -3688,7 +3688,7 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_scan_token(LEFT_PAR)) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_172()) jj_scanpos = xsp;
+    if (jj_3R_171()) jj_scanpos = xsp;
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
   }
@@ -3969,7 +3969,7 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_201() {
+  private boolean jj_3R_199() {
     if (jj_scan_token(COMMA)) return true;
     if (jj_3R_14()) return true;
     return false;
@@ -4019,23 +4019,23 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_178() {
+  private boolean jj_3R_177() {
     if (jj_3R_21()) return true;
     return false;
   }
 
-  private boolean jj_3R_171() {
+  private boolean jj_3R_170() {
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_170()) return true;
+    if (jj_3R_169()) return true;
     return false;
   }
 
-  private boolean jj_3R_176() {
+  private boolean jj_3R_175() {
     if (jj_3R_21()) return true;
     return false;
   }
 
-  private boolean jj_3R_197() {
+  private boolean jj_3R_195() {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_scan_token(8)) {
@@ -4045,10 +4045,10 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_191() {
+  private boolean jj_3R_189() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_197()) jj_scanpos = xsp;
+    if (jj_3R_195()) jj_scanpos = xsp;
     if (jj_scan_token(UNSIGNED_INTEGER)) return true;
     return false;
   }
@@ -4074,9 +4074,9 @@ public class ADQLParser implements ADQLParserConstants {
   private boolean jj_3R_158() {
     if (jj_scan_token(POINT)) return true;
     if (jj_scan_token(LEFT_PAR)) return true;
-    if (jj_3R_169()) return true;
+    if (jj_3R_168()) return true;
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_170()) return true;
+    if (jj_3R_169()) return true;
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
   }
@@ -4094,14 +4094,14 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_200() {
+  private boolean jj_3R_198() {
     if (jj_scan_token(USING)) return true;
     if (jj_scan_token(LEFT_PAR)) return true;
     if (jj_3R_14()) return true;
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_201()) { jj_scanpos = xsp; break; }
+      if (jj_3R_199()) { jj_scanpos = xsp; break; }
     }
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
@@ -4115,17 +4115,17 @@ public class ADQLParser implements ADQLParserConstants {
   private boolean jj_3R_140() {
     if (jj_scan_token(POLYGON)) return true;
     if (jj_scan_token(LEFT_PAR)) return true;
+    if (jj_3R_168()) return true;
+    if (jj_scan_token(COMMA)) return true;
     if (jj_3R_169()) return true;
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_170()) return true;
+    if (jj_3R_169()) return true;
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_170()) return true;
-    if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_170()) return true;
+    if (jj_3R_169()) return true;
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_171()) { jj_scanpos = xsp; break; }
+      if (jj_3R_170()) { jj_scanpos = xsp; break; }
     }
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
@@ -4146,7 +4146,7 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_199() {
+  private boolean jj_3R_197() {
     if (jj_scan_token(ON)) return true;
     if (jj_3R_163()) return true;
     return false;
@@ -4175,9 +4175,9 @@ public class ADQLParser implements ADQLParserConstants {
   private boolean jj_3R_138() {
     if (jj_scan_token(CIRCLE)) return true;
     if (jj_scan_token(LEFT_PAR)) return true;
-    if (jj_3R_169()) return true;
+    if (jj_3R_168()) return true;
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_170()) return true;
+    if (jj_3R_169()) return true;
     if (jj_scan_token(COMMA)) return true;
     if (jj_3R_108()) return true;
     if (jj_scan_token(RIGHT_PAR)) return true;
@@ -4201,9 +4201,9 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_scan_token(JOIN)) return true;
     if (jj_3R_51()) return true;
     xsp = jj_scanpos;
-    if (jj_3R_199()) {
+    if (jj_3R_197()) {
     jj_scanpos = xsp;
-    if (jj_3R_200()) return true;
+    if (jj_3R_198()) return true;
     }
     return false;
   }
@@ -4229,9 +4229,9 @@ public class ADQLParser implements ADQLParserConstants {
   private boolean jj_3R_136() {
     if (jj_scan_token(BOX)) return true;
     if (jj_scan_token(LEFT_PAR)) return true;
-    if (jj_3R_169()) return true;
+    if (jj_3R_168()) return true;
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_170()) return true;
+    if (jj_3R_169()) return true;
     if (jj_scan_token(COMMA)) return true;
     if (jj_3R_108()) return true;
     if (jj_scan_token(COMMA)) return true;
@@ -4240,7 +4240,7 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_192() {
+  private boolean jj_3R_190() {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_scan_token(22)) jj_scanpos = xsp;
@@ -4248,12 +4248,12 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_182() {
+  private boolean jj_3R_181() {
     if (jj_3R_21()) return true;
     return false;
   }
 
-  private boolean jj_3R_190() {
+  private boolean jj_3R_188() {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_scan_token(45)) {
@@ -4263,12 +4263,12 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_183() {
+  private boolean jj_3R_182() {
     if (jj_3R_46()) return true;
     return false;
   }
 
-  private boolean jj_3R_180() {
+  private boolean jj_3R_179() {
     if (jj_3R_21()) return true;
     return false;
   }
@@ -4295,17 +4295,17 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_181() {
+  private boolean jj_3R_180() {
     if (jj_3R_158()) return true;
     return false;
   }
 
-  private boolean jj_3R_177() {
+  private boolean jj_3R_176() {
     if (jj_3R_158()) return true;
     return false;
   }
 
-  private boolean jj_3R_175() {
+  private boolean jj_3R_174() {
     if (jj_3R_158()) return true;
     return false;
   }
@@ -4320,35 +4320,35 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_169() {
+  private boolean jj_3R_168() {
     if (jj_3R_27()) return true;
     return false;
   }
 
-  private boolean jj_3R_198() {
+  private boolean jj_3R_196() {
     if (jj_3R_17()) return true;
     return false;
   }
 
   private boolean jj_3R_117() {
     if (jj_scan_token(LEFT_PAR)) return true;
-    if (jj_3R_193()) return true;
+    if (jj_3R_191()) return true;
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
   }
 
-  private boolean jj_3R_193() {
+  private boolean jj_3R_191() {
     if (jj_3R_72()) return true;
     Token xsp;
-    if (jj_3R_198()) return true;
+    if (jj_3R_196()) return true;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_198()) { jj_scanpos = xsp; break; }
+      if (jj_3R_196()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
 
-  private boolean jj_3R_179() {
+  private boolean jj_3R_178() {
     if (jj_3R_158()) return true;
     return false;
   }
@@ -4362,7 +4362,7 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_3R_77()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_192()) jj_scanpos = xsp;
+    if (jj_3R_190()) jj_scanpos = xsp;
     return false;
   }
 
@@ -4390,15 +4390,15 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_scan_token(LEFT_PAR)) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_179()) {
+    if (jj_3R_178()) {
     jj_scanpos = xsp;
-    if (jj_3R_180()) return true;
+    if (jj_3R_179()) return true;
     }
     if (jj_scan_token(COMMA)) return true;
     xsp = jj_scanpos;
-    if (jj_3R_181()) {
+    if (jj_3R_180()) {
     jj_scanpos = xsp;
-    if (jj_3R_182()) return true;
+    if (jj_3R_181()) return true;
     }
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
@@ -4409,9 +4409,9 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_scan_token(LEFT_PAR)) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_177()) {
+    if (jj_3R_176()) {
     jj_scanpos = xsp;
-    if (jj_3R_178()) return true;
+    if (jj_3R_177()) return true;
     }
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
@@ -4422,9 +4422,9 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_scan_token(LEFT_PAR)) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_175()) {
+    if (jj_3R_174()) {
     jj_scanpos = xsp;
-    if (jj_3R_176()) return true;
+    if (jj_3R_175()) return true;
     }
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
@@ -4472,20 +4472,20 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_189() {
+  private boolean jj_3R_187() {
     if (jj_3R_36()) return true;
     return false;
   }
 
-  private boolean jj_3R_166() {
+  private boolean jj_3R_165() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_189()) {
+    if (jj_3R_187()) {
     jj_scanpos = xsp;
     if (jj_scan_token(101)) return true;
     }
     xsp = jj_scanpos;
-    if (jj_3R_190()) jj_scanpos = xsp;
+    if (jj_3R_188()) jj_scanpos = xsp;
     return false;
   }
 
@@ -4529,7 +4529,7 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_170() {
+  private boolean jj_3R_169() {
     if (jj_3R_108()) return true;
     if (jj_scan_token(COMMA)) return true;
     if (jj_3R_108()) return true;
@@ -4545,24 +4545,9 @@ public class ADQLParser implements ADQLParserConstants {
     xsp = jj_scanpos;
     if (jj_scan_token(10)) {
     jj_scanpos = xsp;
-    if (jj_3R_183()) return true;
+    if (jj_3R_182()) return true;
     }
     if (jj_scan_token(RIGHT_PAR)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_188() {
-    if (jj_3R_36()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_164() {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_188()) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(101)) return true;
-    }
     return false;
   }
 
@@ -4702,9 +4687,9 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_167() {
+  private boolean jj_3R_166() {
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_166()) return true;
+    if (jj_3R_165()) return true;
     return false;
   }
 
@@ -4739,11 +4724,11 @@ public class ADQLParser implements ADQLParserConstants {
 
   private boolean jj_3R_155() {
     if (jj_scan_token(ORDER_BY)) return true;
-    if (jj_3R_166()) return true;
+    if (jj_3R_165()) return true;
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_167()) { jj_scanpos = xsp; break; }
+      if (jj_3R_166()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
@@ -4778,9 +4763,9 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_165() {
+  private boolean jj_3R_164() {
     if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_164()) return true;
+    if (jj_3R_46()) return true;
     return false;
   }
 
@@ -4794,7 +4779,7 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_184() {
+  private boolean jj_3R_183() {
     if (jj_scan_token(AS)) return true;
     if (jj_3R_14()) return true;
     return false;
@@ -4802,11 +4787,11 @@ public class ADQLParser implements ADQLParserConstants {
 
   private boolean jj_3R_153() {
     if (jj_scan_token(GROUP_BY)) return true;
-    if (jj_3R_164()) return true;
+    if (jj_3R_46()) return true;
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_165()) { jj_scanpos = xsp; break; }
+      if (jj_3R_164()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
@@ -4871,7 +4856,7 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_3R_46()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_184()) jj_scanpos = xsp;
+    if (jj_3R_183()) jj_scanpos = xsp;
     return false;
   }
 
@@ -4884,34 +4869,34 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_195() {
+  private boolean jj_3R_193() {
     if (jj_scan_token(LEFT_PAR)) return true;
     if (jj_3R_163()) return true;
     if (jj_scan_token(RIGHT_PAR)) return true;
     return false;
   }
 
-  private boolean jj_3R_194() {
+  private boolean jj_3R_192() {
     if (jj_3R_25()) return true;
     return false;
   }
 
-  private boolean jj_3R_186() {
+  private boolean jj_3R_185() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_194()) {
+    if (jj_3R_192()) {
     jj_scanpos = xsp;
-    if (jj_3R_195()) return true;
+    if (jj_3R_193()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_196() {
+  private boolean jj_3R_194() {
     if (jj_scan_token(NOT)) return true;
     return false;
   }
 
-  private boolean jj_3R_187() {
+  private boolean jj_3R_186() {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_scan_token(33)) {
@@ -4919,8 +4904,8 @@ public class ADQLParser implements ADQLParserConstants {
     if (jj_scan_token(34)) return true;
     }
     xsp = jj_scanpos;
-    if (jj_3R_196()) jj_scanpos = xsp;
-    if (jj_3R_186()) return true;
+    if (jj_3R_194()) jj_scanpos = xsp;
+    if (jj_3R_185()) return true;
     return false;
   }
 
@@ -4939,7 +4924,7 @@ public class ADQLParser implements ADQLParserConstants {
     return false;
   }
 
-  private boolean jj_3R_185() {
+  private boolean jj_3R_184() {
     if (jj_scan_token(NOT)) return true;
     return false;
   }
@@ -5170,18 +5155,21 @@ public class ADQLParser implements ADQLParserConstants {
       for (int i = 0; i < jj_endpos; i++) {
         jj_expentry[i] = jj_lasttokens[i];
       }
-      jj_entries_loop: for (java.util.Iterator<?> it = jj_expentries.iterator(); it.hasNext();) {
+      boolean exists = false;
+      for (java.util.Iterator<?> it = jj_expentries.iterator(); it.hasNext();) {
+        exists = true;
         int[] oldentry = (int[])(it.next());
         if (oldentry.length == jj_expentry.length) {
           for (int i = 0; i < jj_expentry.length; i++) {
             if (oldentry[i] != jj_expentry[i]) {
-              continue jj_entries_loop;
+              exists = false;
+              break;
             }
           }
-          jj_expentries.add(jj_expentry);
-          break jj_entries_loop;
+          if (exists) break;
         }
       }
+      if (!exists) jj_expentries.add(jj_expentry);
       if (pos != 0) jj_lasttokens[(jj_endpos = pos) - 1] = kind;
     }
   }

--- a/src/adql/parser/ADQLQueryFactory.java
+++ b/src/adql/parser/ADQLQueryFactory.java
@@ -89,14 +89,14 @@ import adql.query.operand.function.geometry.RegionFunction;
  */
 public class ADQLQueryFactory {
 
-	/**
-	 * Type of table JOIN.
-	 * 
-	 * @author Gr&eacute;gory Mantelet (CDS)
-	 * @version 1.0 (08/2011)
-	 */
-	public static enum JoinType{
-		CROSS, INNER, OUTER_LEFT, OUTER_RIGHT, OUTER_FULL;
+	protected boolean allowUnknownFunctions = true;
+
+	public static enum JoinType {
+		CROSS,
+		INNER,
+		OUTER_LEFT,
+		OUTER_RIGHT,
+		OUTER_FULL;
 	}
 
 	/**
@@ -106,6 +106,9 @@ public class ADQLQueryFactory {
 		;
 	}
 
+	public ADQLQueryFactory(boolean allowUnknownFunctions){
+		this.allowUnknownFunctions = allowUnknownFunctions;
+	}
 	public ADQLQuery createQuery() throws Exception{
 		return new ADQLQuery();
 	}
@@ -295,8 +298,11 @@ public class ADQLQueryFactory {
 	 * 
 	 * @throws Exception	If there is a problem while creating the function.
 	 */
-	public UserDefinedFunction createUserDefinedFunction(String name, ADQLOperand[] params) throws Exception{
-		return new DefaultUDF(name, params);
+	public UserDefinedFunction createUserDefinedFunction(String name, ADQLOperand[] params) throws Exception {
+		if (allowUnknownFunctions)
+			return new DefaultUDF(name, params);
+		else
+			throw new UnsupportedOperationException("No ADQL function called \""+name+"\" !");
 	}
 
 	public DistanceFunction createDistance(PointFunction point1, PointFunction point2) throws Exception{

--- a/src/adql/parser/adqlGrammar.jj
+++ b/src/adql/parser/adqlGrammar.jj
@@ -809,9 +809,9 @@ void Where(): {ClauseConstraints where = query.getWhere(); ADQLConstraint condit
 	<WHERE> ConditionsList(where)
 }
 
-void GroupBy(): {ClauseADQL<ColumnReference> groupBy = query.getGroupBy(); ColumnReference colRef = null;} {
-	<GROUP_BY> colRef=ColumnRef() { groupBy.add(colRef); }
-	( <COMMA> colRef=ColumnRef() { groupBy.add(colRef); } )*
+void GroupBy(): {ClauseADQL<ADQLOperand> groupBy = query.getGroupBy(); ADQLOperand colRef = null;} {
+	<GROUP_BY> colRef=ValueExpression() { groupBy.add(colRef); }
+	( <COMMA> colRef=ValueExpression() { groupBy.add(colRef); } )*
 }
 
 void Having(): {ClauseConstraints having = query.getHaving();} {
@@ -1121,7 +1121,8 @@ ADQLOperand StringFactor(): {ADQLOperand op;} {
 GeometryValue<GeometryFunction> GeometryExpression(): {ADQLColumn col = null; GeometryFunction gf = null;} {
 	(col=Column() | gf=GeometryValueFunction())
 	{
-		if (col != null){		  	col.setExpectedType('G');
+		if (col != null){
+		  	col.setExpectedType('G');
 			return new GeometryValue<GeometryFunction>(col);
 		}else
 			return new GeometryValue<GeometryFunction>(gf);
@@ -1294,7 +1295,8 @@ GeometryFunction GeometryFunction(): {Token t=null; GeometryValue<GeometryFuncti
 				{
 					if (p1 != null)
 						gvp1 = new GeometryValue<PointFunction>(p1);
-					else{						col1.setExpectedType('G');
+					else{
+						col1.setExpectedType('G');
 						gvp1 = new GeometryValue<PointFunction>(col1);
 					}
 				}
@@ -1303,7 +1305,8 @@ GeometryFunction GeometryFunction(): {Token t=null; GeometryValue<GeometryFuncti
 				{
 					if (p2 != null)
 						gvp2 = new GeometryValue<PointFunction>(p2);
-					else{						col2.setExpectedType('G');
+					else{
+						col2.setExpectedType('G');
 						gvp2 = new GeometryValue<PointFunction>(col2);
 					}
 				} 

--- a/src/adql/query/SelectItem.java
+++ b/src/adql/query/SelectItem.java
@@ -157,9 +157,25 @@ public class SelectItem implements ADQLObject {
 		return new SelectItem(this);
 	}
 
-	public String getName(){
-		return hasAlias() ? alias : operand.getName();
-	}
+
+	public String getName() {
+
+    	if (hasAlias())
+    	    {
+    	    return getAlias();
+    	    }
+        else {
+            if (operand instanceof Operation)
+                {
+                Operation op = (Operation) operand;
+                return op.getOperation().name();
+                }
+            else {
+                return operand.getName();
+                }
+    	    }
+    	}
+
 
 	public ADQLIterator adqlIterator(){
 		return new ADQLIterator(){

--- a/src/adql/query/operand/NegativeOperand.java
+++ b/src/adql/query/operand/NegativeOperand.java
@@ -96,7 +96,7 @@ public final class NegativeOperand implements ADQLOperand {
 
 	@Override
 	public String getName(){
-		return "-" + operand.getName();
+		return operand.getName();
 	}
 
 	@Override

--- a/src/adql/query/operand/NumericConstant.java
+++ b/src/adql/query/operand/NumericConstant.java
@@ -32,7 +32,7 @@ import adql.query.NullADQLIterator;
  */
 public final class NumericConstant implements ADQLOperand {
 
-	private String value;
+	protected String value;
 
 	/**
 	 * The numeric value is saved as a string so that the exact user format can be saved.
@@ -93,7 +93,7 @@ public final class NumericConstant implements ADQLOperand {
 		return value;
 	}
 
-	public final double getNumericValue(){
+	public double getNumericValue(){
 		try{
 			return Double.parseDouble(value);
 		}catch(NumberFormatException nfe){
@@ -106,7 +106,7 @@ public final class NumericConstant implements ADQLOperand {
 	 * 
 	 * @param value		The numeric value.
 	 */
-	public final void setValue(long value){
+	public void setValue(long value){
 		this.value = "" + value;
 	}
 
@@ -115,7 +115,7 @@ public final class NumericConstant implements ADQLOperand {
 	 * 
 	 * @param value		The numeric value.
 	 */
-	public final void setValue(double value){
+	public void setValue(double value){
 		this.value = "" + value;
 	}
 
@@ -140,7 +140,7 @@ public final class NumericConstant implements ADQLOperand {
 	 * @param checkNumeric				<i>true</i> to check whether the given value is numeric, <i>false</i> otherwise.
 	 * @throws NumberFormatException	If the given value can not be converted in a Double.
 	 */
-	public final void setValue(String value, boolean checkNumeric) throws NumberFormatException{
+	public void setValue(String value, boolean checkNumeric) throws NumberFormatException{
 		if (checkNumeric)
 			Double.parseDouble(value);
 

--- a/src/adql/query/operand/NumericConstant.java
+++ b/src/adql/query/operand/NumericConstant.java
@@ -180,7 +180,19 @@ public final class NumericConstant implements ADQLOperand {
 	public String getName(){
 		return value;
 	}
-
+	
+    /**
+     * Get the Numeric Constant as LONG
+     * @return long LONG value of Numeric constant
+     */
+	public long getIntegerValue() {
+        try{
+            return Long.parseLong(value);
+        } catch(NumberFormatException nfe){
+            return 0L;
+        }
+    }
+	
 	@Override
 	public ADQLIterator adqlIterator(){
 		return new NullADQLIterator();

--- a/src/adql/query/operand/Operation.java
+++ b/src/adql/query/operand/Operation.java
@@ -187,9 +187,8 @@ public class Operation implements ADQLOperand {
 		return new Operation(this);
 	}
 
-	@Override
-	public String getName(){
-		return operation.toString();
+	public String getName() {
+		return operation.name();
 	}
 
 	@Override

--- a/src/adql/query/operand/WrappedOperand.java
+++ b/src/adql/query/operand/WrappedOperand.java
@@ -78,9 +78,8 @@ public class WrappedOperand implements ADQLOperand {
 		return new WrappedOperand((ADQLOperand)operand.getCopy());
 	}
 
-	@Override
-	public String getName(){
-		return "(" + operand.getName() + ")";
+	public String getName() {
+		return operand.getName();
 	}
 
 	@Override

--- a/src/adql/translator/JDBCTranslator.java
+++ b/src/adql/translator/JDBCTranslator.java
@@ -767,7 +767,7 @@ public abstract class JDBCTranslator implements ADQLTranslator {
 	 * 
 	 * @throws TranslationException	If there is an error during the translation.
 	 */
-	protected final String getDefaultADQLFunction(ADQLFunction fct) throws TranslationException{
+	protected String getDefaultADQLFunction(ADQLFunction fct) throws TranslationException{
 		String sql = fct.getName() + "(";
 
 		for(int i = 0; i < fct.getNbParameters(); i++)

--- a/src/adql/translator/PostgreSQLTranslator.java
+++ b/src/adql/translator/PostgreSQLTranslator.java
@@ -102,6 +102,27 @@ public class PostgreSQLTranslator extends JDBCTranslator {
 	public boolean isCaseSensitive(final IdentifierField field){
 		return field == null ? false : field.isCaseSensitive(caseSensitivity);
 	}
+	
+	/**
+	 * Appends the full name of the given table to the given StringBuffer.
+	 * 
+	 * @param str		The string buffer.
+	 * @param dbTable	The table whose the full name must be appended.
+	 * 
+	 * @return			The string buffer + full table name.
+	 */
+	public final StringBuffer appendFullDBName(final StringBuffer str, final DBTable dbTable){
+		if (dbTable != null){
+			if (dbTable.getDBCatalogName() != null)
+				appendIdentifier(str, dbTable.getDBCatalogName(), IdentifierField.CATALOG).append('.');
+
+			if (dbTable.getDBSchemaName() != null)
+				appendIdentifier(str, dbTable.getDBSchemaName(), IdentifierField.SCHEMA).append('.');
+
+			appendIdentifier(str, dbTable.getDBName(), IdentifierField.TABLE);
+		}
+		return str;
+	}
 
 	@Override
 	public String translate(StringConstant strConst) throws TranslationException{


### PR DESCRIPTION
ADQL Parser - Allow ADQL Operands in group by clause
Example Query:  
  SELECT
       CAST(ROUND(l*6.0,0) AS INT)/6.0 AS lon,
      CAST(ROUND(b*6.0,0) AS INT)/6.0 AS lat,
      COUNT(*)                        AS num
  FROM
       ATLASDR1.atlasSource
  WHERE
      (priOrSec=0 OR priOrSec=frameSetID)
 GROUP BY
      CAST(ROUND(l*6.0,0) AS INT)/6.0