### PR TITLE
Remove import of tap.data.DataReadException in adql.

### DIFF
--- a/src/adql/translator/JDBCTranslator.java
+++ b/src/adql/translator/JDBCTranslator.java
@@ -77,7 +77,6 @@ import adql.query.operand.function.geometry.IntersectsFunction;
 import adql.query.operand.function.geometry.PointFunction;
 import adql.query.operand.function.geometry.PolygonFunction;
 import adql.query.operand.function.geometry.RegionFunction;
-import tap.data.DataReadException;
 
 /**
  * <p>Implementation of {@link ADQLTranslator} which translates ADQL queries in SQL queries.</p>
@@ -886,7 +885,7 @@ public abstract class JDBCTranslator implements ADQLTranslator {
 	 * 	{@link #convertTypeFromDB(int, String, String, String[])}. So the value should always
 	 * 	be of the expected type and format. However, if it turns out that the type is wrong
 	 * 	and that the conversion is finally impossible, this function SHOULD throw a
-	 * 	{@link DataReadException}.
+	 * 	{@link tap.data.DataReadException}.
 	 * </i></p>
 	 * 
 	 * @param jdbcColValue	A JDBC column value (returned by ResultSet.getObject(int)).


### PR DESCRIPTION
This import can not be resolved in a standalone version of adql. It also creates a circular dependency: ADQL then depends on TAP, which depends on starjava, but starjava depends on ADQL.

BTW, the latter could be a reason to split ADQL from TAP/UWS completely; also since you [mentioned](https://github.com/gmantele/taplib/issues/22#issuecomment-282024897) that ADQL is of general use, while TAP/UWS is server-only.