### PR TITLE
Bugfix: NPE in VotType & MySQL metadata issue in JDBCConnection

### DIFF
--- a/src/tap/db/JDBCConnection.java
+++ b/src/tap/db/JDBCConnection.java
@@ -3271,7 +3271,8 @@ public class JDBCConnection implements DBConnection {
 			int cnt = 0;
 			String columnPattern = columnCaseSensitive ? columnName : null;
 			while(rsT.next()){
-				String rsSchema = nullifyIfNeeded(rsT.getString(2));
+                                int rsTSchemaIndex = dbms.equalsIgnoreCase(DBMS_MYSQL) ? 1 : 2;
+				String rsSchema = nullifyIfNeeded(rsT.getString(rsTSchemaIndex));
 				String rsTable = rsT.getString(3);
 				// test the schema name:
 				if (!supportsSchema || schemaName == null || equals(rsSchema, schemaName, schemaCaseSensitive)){

--- a/src/tap/metadata/VotType.java
+++ b/src/tap/metadata/VotType.java
@@ -160,13 +160,13 @@ public final class VotType {
 
 			case CHAR:
 				this.datatype = VotDatatype.CHAR;
-				this.arraysize = Integer.toString(tapType.length > 0 ? tapType.length : null);
+				this.arraysize = tapType.length > 0 ? Integer.toString(tapType.length) : null;
 				this.xtype = null;
 				break;
 
 			case BINARY:
 				this.datatype = VotDatatype.UNSIGNEDBYTE;
-				this.arraysize = Integer.toString(tapType.length > 0 ? tapType.length : null);
+				this.arraysize = tapType.length > 0 ? Integer.toString(tapType.length) : null;
 				this.xtype = null;
 				break;
 


### PR DESCRIPTION
Hi Grégory,

I've found a small bug in the VotType class: if a null value is passed to the Integer.toString() method a NullPointerException is thrown.

Moreover, I'm using your library with MySQL and it seems that the DatabaseMetaData ResultSet contains the schema_name in position 1 and not 2. I'm using the driver mysql-connector-java-5.1.38.
This caused the isColumnExisting() method returning always null.

With these two small modifications the service is working good for me. I've tested it on GlassFish 4.1.

Cheers,
Sonia

P.S. I'm from INAF-OATs (working with Marco Molinaro)
